### PR TITLE
Make loading of cached assets closer in performance to integrated assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Other
 
+- Load cached assets as fast as integrated assets, see #1753 (@Enselic)
+
 
 ## Syntaxes
 


### PR DESCRIPTION
Using BufReader makes sense for large files, but assets are never large enough
to require buffering. It is significantly faster to load the file contents in
one go, so let's do that instead.

Closes #1753